### PR TITLE
add_photo_from_url functionality

### DIFF
--- a/lib/attachinary/orm/active_record/extension.rb
+++ b/lib/attachinary/orm/active_record/extension.rb
@@ -92,6 +92,18 @@ module Attachinary
         end
       end
 
+      # def add_photo_from_url=('www.foo.com/image.jpg')
+      define_method "add_#{scope}_from_url" do |url|
+        begin
+          data = Cloudinary::Uploader.upload(url)
+        rescue => e
+          return false
+        end
+
+        file = File.new(data)
+        file.scope = scope
+        send("#{scope}=", file)
+      end
 
       if options[:single]
         # def photo

--- a/lib/attachinary/orm/mongoid/extension.rb
+++ b/lib/attachinary/orm/mongoid/extension.rb
@@ -64,6 +64,22 @@ module Attachinary
         options
       end
 
+      # def add_photo_from_url=('www.foo.com/image.jpg')
+      define_method "add_#{scope}_from_url" do |url|
+        begin
+          data = Cloudinary::Uploader.upload(url)
+        rescue => e
+          return false
+        end
+
+        file = File.new(data)
+        file.scope = scope
+        if options[:single]
+          send("#{scope}=", file)
+        else
+          send("#{scope}=", [file])
+        end
+      end
 
       # alias_method :orig_photo=, :photo=
       # def photo=(arg)


### PR DESCRIPTION
This update allows you to call "add_#{scope}_from_url" on your attachinary models to update your model files from a target URL. I don't have mongo setup right now, so if somebody could run the mongo version on their machine that'd be great. Let me know if there are any problems. Thanks.
