### PR TITLE
resource_type missing

### DIFF
--- a/lib/attachinary/orm/base_extension.rb
+++ b/lib/attachinary/orm/base_extension.rb
@@ -44,7 +44,7 @@ module Attachinary
           #   ...
           # end
           define_method :"#{options[:scope]}_url=" do |url|
-            send(:"#{options[:scope]}=", Cloudinary::Uploader.upload(url))
+            send(:"#{options[:scope]}=", Cloudinary::Uploader.upload(url, resource_type: "auto"))
           end
 
         else
@@ -52,7 +52,7 @@ module Attachinary
           #   ...
           # end
           define_method :"#{options[:singular]}_urls=" do |urls|
-            send(:"#{options[:scope]}=", urls.map { |url| Cloudinary::Uploader.upload(url) })
+            send(:"#{options[:scope]}=", urls.map { |url| Cloudinary::Uploader.upload(url, resource_type: "auto") })
           end
         end
 


### PR DESCRIPTION
Hello

The `resource_type: 'auto'`parameter appears in `attachinary_file_field_options` while it is not present in the `photo_url=` and `image_urls=` methods.
