### PR TITLE
Added support for ordering images

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,12 @@ class User < ActiveRecord::Base
 end
 ```
 
+The `has_attachments` methods support some options. Notably, you can support ordered images by adding a `position` column to the `attachinary_files` table and doing this:
+
+```ruby
+  has_attachments :photos, order: 'position ASC'
+```
+
 In our `_form.html.erb` template, we need to add only this:
 
 ```erb

--- a/lib/attachinary/orm/active_record/extension.rb
+++ b/lib/attachinary/orm/active_record/extension.rb
@@ -13,7 +13,8 @@ module Attachinary
         as: :attachinariable,
         class_name: '::Attachinary::File',
         conditions: { scope: options[:scope].to_s },
-        dependent: :destroy
+        dependent: :destroy,
+        order: options[:order]
 
 
       # def photo=(file)


### PR DESCRIPTION
By passing through an `order` option to has_attachments, we support ordering images by position (or any other attribute).
