### PR TITLE
IE CORS Support [Fix #42]

### DIFF
--- a/app/controllers/attachinary/cors_controller.rb
+++ b/app/controllers/attachinary/cors_controller.rb
@@ -3,7 +3,7 @@ module Attachinary
     respond_to :json
 
     def show
-      respond_with request.query_parameters
+      respond_with request.query_parameters, :content_type => 'text/plain'
     end
   end
 end


### PR DESCRIPTION
Ensures correct content type (text/plain) is set so that IE works. Current behavior prior to this fix is that IE asks to download a file named cors and the upload doesn't work correctly.
