### PR TITLE
Bug with multiple submit buttons in one form

### DIFF
--- a/lib/assets/javascripts/attachinary.js.coffee
+++ b/lib/assets/javascripts/attachinary.js.coffee
@@ -69,7 +69,9 @@
 
         @$input.prop 'disabled', true
         if @config.disableWith
-          @$submit.data 'old-val', @$submit.val()
+          @$submit.each (index,input) =>
+            $input = $(input)
+            $input.data 'old-val', $input.val()
           @$submit.val  @config.disableWith
           @$submit.prop 'disabled', true
 
@@ -91,7 +93,9 @@
 
         @checkMaximum()
         if @config.disableWith
-          @$submit.val  @$submit.data('old-val')
+          @$submit.each (index,input) =>
+            $input = $(input)
+            $input.val  $input.data('old-val')
           @$submit.prop 'disabled', false
 
 


### PR DESCRIPTION
Bug: Having multiple submit buttons in my form (save, close&save, cancel), after uploading an image with attachinary, all submit butons have the same text as the first button.

Sollution: Loop over jquery collection of submit buttons before and after the upload and carry out the changing of the button text for each submit button on it's own.
