### PR TITLE
Bad browsers (IE) can put '[null]' into the attachinary hash

### DIFF
--- a/lib/attachinary/utils.rb
+++ b/lib/attachinary/utils.rb
@@ -2,7 +2,7 @@ module Attachinary
   module Utils
 
     def self.process_json(json, scope=nil)
-      [JSON.parse(json)].flatten.map do |data|
+      [JSON.parse(json)].flatten.compact.map do |data|
         process_hash(data, scope)
       end
     end

--- a/lib/attachinary/version.rb
+++ b/lib/attachinary/version.rb
@@ -1,3 +1,3 @@
 module Attachinary
-  VERSION = "1.2.3"
+  VERSION = "1.2.4"
 end

--- a/spec/models/note_spec.rb
+++ b/spec/models/note_spec.rb
@@ -49,6 +49,12 @@ describe Note do
         subject.photo.public_id.should == file.public_id
       end
 
+      it 'handles invalid JSON from bad browsers (IE)' do
+        file = build(:file)
+        subject.photo = "[null]"
+        subject.photo.should be_nil
+      end
+
       it 'accepts IO objects' do
         image = StringIO.new("")
         file = build(:file)


### PR DESCRIPTION
IE in some cases can submit "[null]" for the attachinary hash. This causes attachinary to blow up with an undefined method [] for NilClass error. This very simple pull request handles bad input by compacting the array to get rid of null elements.
