### PR TITLE
implemented raw file type handling

### DIFF
--- a/lib/assets/javascripts/attachinary.js.coffee
+++ b/lib/assets/javascripts/attachinary.js.coffee
@@ -10,9 +10,13 @@
         <ul>
           <% for(var i=0; i<files.length; i++){ %>
             <li>
-              <img
-                src="<%= $.cloudinary.url(files[i].public_id, { "version": files[i].version, "format": 'jpg', "crop": 'fill', "width": 75, "height": 75 }) %>"
-                alt="" width="75" height="75" />
+              <% if(files[i].resource_type == "raw") { %>
+                <div class="raw-file"></div>
+              <% } else { %>
+                <img
+                  src="<%= $.cloudinary.url(files[i].public_id, { "version": files[i].version, "format": 'jpg', "crop": 'fill', "width": 75, "height": 75 }) %>"
+                  alt="" width="75" height="75" />
+              <% } %>
               <a href="#" data-remove="<%= files[i].public_id %>">Remove</a>
             </li>
           <% } %>
@@ -106,7 +110,7 @@
 
 
     addFile: (file) ->
-      if !@options.accept || $.inArray(file.format, @options.accept) != -1
+      if !@options.accept || $.inArray(file.format, @options.accept) != -1  || $.inArray(file.resource_type, @options.accept) != -1
         @files.push file
         @redraw()
         @checkMaximum()


### PR DESCRIPTION
I made a small improvement to make cloudinary raw/non-image files possible.

has_attachment :video, accept: [:raw, :mpg, :mpeg, :mp4]

Will make .mpg .mpeg and .mp4 files possible. Because raw files do not have thumbnails a placeholder div is gonna be added to the widget that can be customized with css.

The only downside is, that in this case also .raw files could be uploaded. I haven't figured out a way to solve this.
