### PR TITLE
Implemented configuration option to skip deletion of the cloudinary resource on destory

### DIFF
--- a/lib/attachinary/orm/file_mixin.rb
+++ b/lib/attachinary/orm/file_mixin.rb
@@ -27,6 +27,11 @@ module Attachinary
 
   private
     def destroy_file
+      metadata = attachinariable.send "#{self.scope}_metadata"
+      if metadata.has_key?(:delete_resource_on_destroy) && metadata[:delete_resource_on_destroy] == false
+        # do not delete the resource on cloudinary
+        return
+      end
       Cloudinary::Uploader.destroy(public_id) if public_id
     end
 


### PR DESCRIPTION
We've ran into the problem, that when using multiple installations of a rails app "dev/test/prod", it might be very dangerous if anybody deletes models in the development system. As attachinary destroys it's resources on cloudinary, this might lead to missing images in production.

As solution, I've implemented a configuration option to skip deletion of the cloudinary resource.

```
# will only destroy cloudinary resources in production
has_attachment :video, accept: [:jpg], delete_resource_on_destroy: Rails.env.production? 
```
