### PR TITLE
Correct order for compound index

### DIFF
--- a/db/migrate/20120612112526_create_attachinary_tables.rb
+++ b/db/migrate/20120612112526_create_attachinary_tables.rb
@@ -12,6 +12,6 @@ class CreateAttachinaryTables < ActiveRecord::Migration
       t.string :resource_type
       t.timestamps
     end
-    add_index :attachinary_files, [:attachinariable_type, :attachinariable_id, :scope], name: 'by_scoped_parent'
+    add_index :attachinary_files, [:attachinariable_id, :attachinariable_type, :scope], name: 'by_scoped_parent'
   end
 end


### PR DESCRIPTION
The order of the index is off by one. This will speed up queries.

```
SELECT `attachinary_files`.* FROM `attachinary_files` WHERE `attachinary_files`.`attachinariable_id` = ? AND `attachinary_files`.`attachinariable_type` = ? AND `attachinary_files`.`scope` = ? LIMIT ?
```
