### PR TITLE
Use SVG status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Attachinary
 
-[![Gem Version](https://badge.fury.io/rb/attachinary.png)](http://badge.fury.io/rb/attachinary)
+[![Gem Version](https://img.shields.io/gem/v/attachinary.svg)](https://rubygems.org/gems/attachinary)
 
 _Note: v1 is not backward compatible. Refer to [wiki](https://github.com/assembler/attachinary/wiki/Upgrading-to-v1.0) on how to upgrade._
 


### PR DESCRIPTION
http://shields.io/ provides many standardized badges for OSS. The PNG versions provided by Shields are similar to the image currently used, but the SVG version added here is more legible on high pixel density displays.
