### PR TITLE
Custom files_container_selector

### DIFF
--- a/lib/assets/javascripts/attachinary.js.coffee
+++ b/lib/assets/javascripts/attachinary.js.coffee
@@ -148,8 +148,8 @@
 
 
     addFilesContainer: ->
-      if @options.files_container_selector? and $(@options.files_container_selector).length > 0
-        @$filesContainer = $(@options.files_container_selector)
+      if @config.files_container_selector? and $(@config.files_container_selector).length > 0
+        @$filesContainer = $(@config.files_container_selector)
       else
         @$filesContainer = $('<div class="attachinary_container">')
         @$input.after @$filesContainer


### PR DESCRIPTION
This adds the ability to specify a custom target for the files_container_selector:

```
$('.attachinary-input').attachinary({ files_container_selector: "#preview-image" })
```
