### PR TITLE
Add required `wrapper_options` to input method

### DIFF
--- a/lib/attachinary/simple_form.rb
+++ b/lib/attachinary/simple_form.rb
@@ -1,7 +1,7 @@
 class AttachinaryInput < SimpleForm::Inputs::Base
   attr_reader :attachinary_options
 
-  def input
+  def input(wrapper_options={})
     template.builder_attachinary_file_field_tag attribute_name, @builder, { html: input_html_options }
   end
 end


### PR DESCRIPTION
Simple Form gem (as of 3.1.0) now requires that any implementation of the input
method now accepts a `wrapper_options` argument. The method definition
without the argument is deprecated and will be removed in the next
Simple Form version. This adds the required parameter and defaults it
to an empty hash.

Fixes #99