### PR TITLE
Add ability to specify jquery-file-upload pasteZone option

### DIFF
--- a/lib/assets/javascripts/attachinary.js.coffee
+++ b/lib/assets/javascripts/attachinary.js.coffee
@@ -65,6 +65,8 @@
       # attach the pasteZone option if the user has specified it
       if @options.pasteZone
         options.pasteZone = @options.pasteZone
+      else if @config.pasteZone
+        options.pasteZone = @config.pasteZone
 
       if @$input.attr('accept')
         options.acceptFileTypes = new RegExp("^#{@$input.attr('accept').split(",").join("|")}$", "i")

--- a/lib/assets/javascripts/attachinary.js.coffee
+++ b/lib/assets/javascripts/attachinary.js.coffee
@@ -62,6 +62,10 @@
         dropZone: @config.dropZone || @$input
         sequentialUploads: true
 
+      # attach the pasteZone option if the user has specified it
+      if @options.pasteZone
+        options.pasteZone = @options.pasteZone
+
       if @$input.attr('accept')
         options.acceptFileTypes = new RegExp("^#{@$input.attr('accept').split(",").join("|")}$", "i")
 

--- a/lib/assets/javascripts/attachinary.js.coffee
+++ b/lib/assets/javascripts/attachinary.js.coffee
@@ -63,9 +63,9 @@
         sequentialUploads: true
 
       # attach the pasteZone option if the user has specified it
-      if @options.pasteZone
+      if @options.pasteZone != undefined
         options.pasteZone = @options.pasteZone
-      else if @config.pasteZone
+      else if @config.pasteZone != undefined
         options.pasteZone = @config.pasteZone
 
       if @$input.attr('accept')


### PR DESCRIPTION
This is a pretty specific need to my project, but we had an issue where users were trying to paste content into the page and the jquery file upload plugin was picking up the paste event and putting it into the multiple attachinary fields. There's a param to control the paste behavior on a more fine-grained level, but I had to add support of it into the gem.