### PR TITLE
Remove responders dependency

### DIFF
--- a/app/controllers/attachinary/cors_controller.rb
+++ b/app/controllers/attachinary/cors_controller.rb
@@ -1,9 +1,10 @@
 module Attachinary
   class CorsController < Attachinary::ApplicationController
-    respond_to :json
 
     def show
-      respond_with request.query_parameters, :content_type => 'text/plain'
+      respond_to do |format|
+        format.json { render json: request.query_parameters, content_type: "text/plain" }
+      end
     end
   end
 end


### PR DESCRIPTION
Rails 4.2 removes class level respond_to and respond_with.  Currently to use the attachinary gem in a rails 4.2 app you have to add the responders gem as a dependency.  This seems like an easier solution that adding responders as a hard dependency of the gem.

I tested that this works for my app, but it does not actually use the cors controller functionality so not all cases have been tested.