### PR TITLE
Replace controller methods removed with Rails 4.2

### DIFF
--- a/app/controllers/attachinary/cors_controller.rb
+++ b/app/controllers/attachinary/cors_controller.rb
@@ -1,9 +1,10 @@
 module Attachinary
   class CorsController < Attachinary::ApplicationController
-    respond_to :json
 
     def show
-      respond_with request.query_parameters, :content_type => 'text/plain'
+      respond_to do |format|
+        format.json { render(json: request.query_parameters, content_type: 'text/plain') }
+      end
     end
   end
 end


### PR DESCRIPTION
`respond_with` and class-level `respond_to` are removed with Rails 4.2
so let's replace them with instance-level `respond_to`

http://edgeguides.rubyonrails.org/4_2_release_notes.html#respond-with-class-level-respond-to