### PR TITLE
CORS support should be opt-in

### DIFF
--- a/lib/attachinary/view_helpers.rb
+++ b/lib/attachinary/view_helpers.rb
@@ -29,10 +29,15 @@ module Attachinary
       api_secret = options[:cloudinary][:api_secret] || Cloudinary.config.api_secret || raise("Must supply api_secret")
 
       cloudinary_params = Cloudinary::Uploader.build_upload_params(options[:cloudinary])
-      cloudinary_params[:callback] = attachinary.cors_url
       cloudinary_params[:signature] = Cloudinary::Utils.api_sign_request(cloudinary_params, api_secret)
       cloudinary_params[:api_key] = api_key
 
+      # If the engine has been mounted it will provide an `attachinary` method
+      # here, otherwise this raises an `undefined local variable or method `attachinary'`
+      # when rendering form file inputs.
+      # Some projects don't have a need for supporting old browsers and won't
+      # have a need to expose this endpoint.
+      cloudinary_params[:callback] = attachinary.cors_url if self.respond_to?(:attachinary)
 
       options[:html] ||= {}
       options[:html][:class] = [options[:html][:class], 'attachinary-input'].flatten.compact


### PR DESCRIPTION
Some projects don't have a need for supporting old browsers and won't have a need to expose that endpoint.

PS: I'd love to write a spec for this behavior but I was not able to get them running as it complains about not being able to find `rails_helper`. Any ideas on how to fix this would be greatly appreciated:

```
 bundle exec rake


-------- ORM: active_record

/Users/fabio/.rbenv/versions/2.2.4/bin/ruby -I/Users/fabio/.rbenv/versions/2.2.4/lib/ruby/gems/2.2.0/gems/rspec-core-3.3.2/lib:/Users/fabio/.rbenv/versions/2.2.4/lib/ruby/gems/2.2.0/gems/rspec-support-3.3.0/lib /Users/fabio/.rbenv/versions/2.2.4/lib/ruby/gems/2.2.0/gems/rspec-core-3.3.2/exe/rspec --pattern spec/\*\*\{,/\*/\*\*\}/\*_spec.rb
/Users/fabio/projects/oss/attachinary/spec/features/notes_spec.rb:1:in `require': cannot load such file -- rails_helper (LoadError)
    from /Users/fabio/projects/oss/attachinary/spec/features/notes_spec.rb:1:in `<top (required)>'
    from /Users/fabio/.rbenv/versions/2.2.4/lib/ruby/gems/2.2.0/gems/rspec-core-3.3.2/lib/rspec/core/configuration.rb:1327:in `load'
    from /Users/fabio/.rbenv/versions/2.2.4/lib/ruby/gems/2.2.0/gems/rspec-core-3.3.2/lib/rspec/core/configuration.rb:1327:in `block in load_spec_files'
    from /Users/fabio/.rbenv/versions/2.2.4/lib/ruby/gems/2.2.0/gems/rspec-core-3.3.2/lib/rspec/core/configuration.rb:1325:in `each'
    from /Users/fabio/.rbenv/versions/2.2.4/lib/ruby/gems/2.2.0/gems/rspec-core-3.3.2/lib/rspec/core/configuration.rb:1325:in `load_spec_files'
    from /Users/fabio/.rbenv/versions/2.2.4/lib/ruby/gems/2.2.0/gems/rspec-core-3.3.2/lib/rspec/core/runner.rb:102:in `setup'
    from /Users/fabio/.rbenv/versions/2.2.4/lib/ruby/gems/2.2.0/gems/rspec-core-3.3.2/lib/rspec/core/runner.rb:88:in `run'
    from /Users/fabio/.rbenv/versions/2.2.4/lib/ruby/gems/2.2.0/gems/rspec-core-3.3.2/lib/rspec/core/runner.rb:73:in `run'
    from /Users/fabio/.rbenv/versions/2.2.4/lib/ruby/gems/2.2.0/gems/rspec-core-3.3.2/lib/rspec/core/runner.rb:41:in `invoke'
    from /Users/fabio/.rbenv/versions/2.2.4/lib/ruby/gems/2.2.0/gems/rspec-core-3.3.2/exe/rspec:4:in `<main>'
/Users/fabio/.rbenv/versions/2.2.4/bin/ruby -I/Users/fabio/.rbenv/versions/2.2.4/lib/ruby/gems/2.2.0/gems/rspec-core-3.3.2/lib:/Users/fabio/.rbenv/versions/2.2.4/lib/ruby/gems/2.2.0/gems/rspec-support-3.3.0/lib /Users/fabio/.rbenv/versions/2.2.4/lib/ruby/gems/2.2.0/gems/rspec-core-3.3.2/exe/rspec --pattern spec/\*\*\{,/\*/\*\*\}/\*_spec.rb failed
```

Cheers!
