### PR TITLE
Access the real file format

### DIFF
--- a/lib/assets/javascripts/attachinary.js.coffee
+++ b/lib/assets/javascripts/attachinary.js.coffee
@@ -113,7 +113,7 @@
 
 
     addFile: (file) ->
-      if !@options.accept || $.inArray(file.format, @options.accept) != -1  || $.inArray(file.resource_type, @options.accept) != -1
+      if !@options.accept || $.inArray(file.public_id.split('.').slice(-1)[0], @options.accept) != -1  || $.inArray(file.resource_type, @options.accept) != -1
         @files.push file
         @redraw()
         @checkMaximum()


### PR DESCRIPTION
This addresses the issue we ran into in #127 where the javascript was alerting a "invalid format" error for file extensions that were whitelisted in the Model.  On further investigation, I discovered the file are still being uploaded to Cloudinary despite the error message the contrary.

Furthermore, `file.format` was undefined, which explained the error message.  I have changed this and it works correctly now.