### PR TITLE
default FileMixin#as_json options argument to nil

### DIFF
--- a/lib/attachinary/orm/file_mixin.rb
+++ b/lib/attachinary/orm/file_mixin.rb
@@ -9,7 +9,7 @@ module Attachinary
       base.after_create  :remove_temporary_tag
     end
 
-    def as_json(options)
+    def as_json(options = nil)
       super(only: [:id, :public_id, :format, :version, :resource_type], methods: [:path])
     end
 
@@ -26,12 +26,12 @@ module Attachinary
       format = options.delete(:format)
       Cloudinary::Utils.cloudinary_url(path(format), options.reverse_merge(:resource_type => resource_type))
     end
-    
+
   protected
     def keep_remote?
       Cloudinary.config.attachinary_keep_remote == true
     end
-    
+
   private
     def destroy_file
       Cloudinary::Uploader.destroy(public_id) if public_id && !keep_remote?


### PR DESCRIPTION
* active_support expects `as_json` to _optionally_ accept an options hash argument
line 93 in https://github.com/rails/rails/blob/master/activesupport/lib/active_support/json/encoding.rb calls as_json without an argument so this breaks when trying to jsonify an attachinary object

* removes trailing whitespace
