### PR TITLE
Update rails and Cloudinary dependencies

### DIFF
--- a/attachinary.gemspec
+++ b/attachinary.gemspec
@@ -16,8 +16,8 @@ Gem::Specification.new do |s|
   s.files = Dir["{app,config,db,lib,vendor}/**/*"] + ["MIT-LICENSE", "Rakefile", "README.md"]
   s.test_files = Dir["test/**/*"]
 
-  s.add_dependency 'rails', '>= 3.2'
-  s.add_dependency 'cloudinary', '~> 1.1.0'
+  s.add_dependency 'rails', '>= 6.0'
+  s.add_dependency 'cloudinary', '~> 1.20.0'
 
   s.add_development_dependency 'sqlite3'
   s.add_development_dependency 'rspec-rails'

--- a/lib/attachinary/version.rb
+++ b/lib/attachinary/version.rb
@@ -1,3 +1,3 @@
 module Attachinary
-  VERSION = "1.3.1"
+  VERSION = "1.3.2"
 end


### PR DESCRIPTION
Cloudinary and rails gems are running at least 6 years behind.