### PR TITLE
Update FileMixin as_json for Ruby 3.3.6 upgrade of Wiki

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     attachinary (1.3.1)
-      cloudinary (~> 1.1.0)
+      cloudinary (~> 1.8)
       rails (>= 3.2)
 
 GEM
@@ -44,7 +44,7 @@ GEM
       thread_safe (~> 0.3, >= 0.3.4)
       tzinfo (~> 1.1)
     addressable (2.3.8)
-    arel (6.0.3)
+    arel (6.0.4)
     aws_cf_signer (0.1.3)
     bson (3.1.2)
     builder (3.2.2)
@@ -57,7 +57,7 @@ GEM
     capybara-webkit (1.6.0)
       capybara (>= 2.3.0, < 2.5.0)
       json
-    cloudinary (1.1.0)
+    cloudinary (1.8.1)
       aws_cf_signer
       rest-client
     coderay (1.1.0)
@@ -68,10 +68,11 @@ GEM
       coffee-script-source
       execjs
     coffee-script-source (1.9.1.1)
+    concurrent-ruby (1.0.5)
     connection_pool (2.2.0)
     database_cleaner (1.4.1)
     diff-lcs (1.2.5)
-    domain_name (0.5.24)
+    domain_name (0.5.20170404)
       unf (>= 0.0.5, < 1.0.0)
     erubis (2.7.0)
     execjs (2.5.2)
@@ -82,8 +83,8 @@ GEM
       railties (>= 3.0.0)
     ffi (1.9.10)
     formatador (0.2.5)
-    globalid (0.3.6)
-      activesupport (>= 4.1.0)
+    globalid (0.4.0)
+      activesupport (>= 4.2.0)
     guard (2.12.8)
       formatador (>= 0.2.4)
       listen (>= 2.7, <= 4.0)
@@ -98,7 +99,7 @@ GEM
       guard (~> 2.1)
       guard-compat (~> 1.1)
       rspec (>= 2.99.0, < 4.0)
-    http-cookie (1.0.2)
+    http-cookie (1.0.3)
       domain_name (~> 0.5)
     i18n (0.7.0)
     jquery-rails (4.0.4)
@@ -114,10 +115,12 @@ GEM
     loofah (2.0.2)
       nokogiri (>= 1.5.9)
     lumberjack (1.0.9)
-    mail (2.6.3)
-      mime-types (>= 1.16, < 3)
+    mail (2.6.6)
+      mime-types (>= 1.16, < 4)
     method_source (0.8.2)
-    mime-types (2.6.1)
+    mime-types (3.1)
+      mime-types-data (~> 3.2015)
+    mime-types-data (3.2016.0521)
     mini_portile (0.6.2)
     minitest (5.7.0)
     mongoid (4.0.2)
@@ -130,7 +133,7 @@ GEM
       connection_pool (~> 2.0)
       optionable (~> 0.2.0)
     nenv (0.2.0)
-    netrc (0.10.3)
+    netrc (0.11.0)
     nokogiri (1.6.6.2)
       mini_portile (~> 0.6.0)
     notiffany (0.0.6)
@@ -173,10 +176,10 @@ GEM
     rb-fsevent (0.9.5)
     rb-inotify (0.9.5)
       ffi (>= 0.5.0)
-    rest-client (1.8.0)
+    rest-client (2.0.2)
       http-cookie (>= 1.0.2, < 2.0)
-      mime-types (>= 1.16, < 3.0)
-      netrc (~> 0.7)
+      mime-types (>= 1.16, < 4.0)
+      netrc (~> 0.8)
     rspec (3.3.0)
       rspec-core (~> 3.3.0)
       rspec-expectations (~> 3.3.0)
@@ -203,12 +206,13 @@ GEM
       actionpack (~> 4.0)
       activemodel (~> 4.0)
     slop (3.6.0)
-    sprockets (3.3.4)
-      rack (~> 1.0)
-    sprockets-rails (2.3.3)
-      actionpack (>= 3.0)
-      activesupport (>= 3.0)
-      sprockets (>= 2.8, < 4.0)
+    sprockets (3.7.1)
+      concurrent-ruby (~> 1.0)
+      rack (> 1, < 3)
+    sprockets-rails (3.2.0)
+      actionpack (>= 4.0)
+      activesupport (>= 4.0)
+      sprockets (>= 3.0.0)
     sqlite3 (1.3.10)
     thor (0.19.1)
     thread_safe (0.3.5)
@@ -216,7 +220,7 @@ GEM
       thread_safe (~> 0.1)
     unf (0.1.4)
       unf_ext
-    unf_ext (0.0.7.1)
+    unf_ext (0.0.7.4)
     valid_attribute (2.0.0)
     xpath (2.0.0)
       nokogiri (~> 1.3)
@@ -241,3 +245,6 @@ DEPENDENCIES
   simple_form
   sqlite3
   valid_attribute
+
+BUNDLED WITH
+   1.11.2

--- a/attachinary.gemspec
+++ b/attachinary.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.test_files = Dir["test/**/*"]
 
   s.add_dependency 'rails', '>= 3.2'
-  s.add_dependency 'cloudinary', '~> 1.8'
+  s.add_dependency 'cloudinary', '~> 1.1'
 
   s.add_development_dependency 'sqlite3'
   s.add_development_dependency 'rspec-rails'

--- a/attachinary.gemspec
+++ b/attachinary.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.test_files = Dir["test/**/*"]
 
   s.add_dependency 'rails', '>= 3.2'
-  s.add_dependency 'cloudinary', '~> 1.1.0'
+  s.add_dependency 'cloudinary', '~> 1.8'
 
   s.add_development_dependency 'sqlite3'
   s.add_development_dependency 'rspec-rails'

--- a/lib/attachinary/orm/file_mixin.rb
+++ b/lib/attachinary/orm/file_mixin.rb
@@ -9,7 +9,7 @@ module Attachinary
       base.after_create  :remove_temporary_tag
     end
 
-    def as_json(options)
+    def as_json(options = {})
       super(only: [:id, :public_id, :format, :version, :resource_type], methods: [:path])
     end
 


### PR DESCRIPTION
Jira: https://doximity.atlassian.net/browse/CSCT-335

Overview
----------
Set default options for `as_json` method in the `FileMixin` module.
This is to prevent the error that occurs when the `as_json` method is called without any options.

This error was discovered when upgrading the wiki to Ruby 3.3.6
- https://github.com/doximity/wiki/pull/596

```
level":"fatal","tags":["d3ddc515-ac56-4706-9b85-d611a3c88f28"],"name":"Rails","exception":{"name":"ActionView::Template::Error","message":"wrong number of arguments (given 0, expected 1)","stack_trace":["/workspace/vendor/cache/attachinary-a72d9b6c151f/lib/attachinary/orm/file_mixin.rb:12:in `as_json'"
```
